### PR TITLE
renamed -disable-version-warning

### DIFF
--- a/xborders
+++ b/xborders
@@ -100,7 +100,7 @@ def get_args():
         help="Whether to place the border on the outside, inside or in the center of windows. Values are `outside`, `inside`, `center`"
     )
     parser.add_argument(
-        "-disable-version-warning",
+        "--disable-version-warning",
         action='store_true',
         help="Send a notification if xborders is out of date."
     )
@@ -395,4 +395,4 @@ if __name__ == "__main__":
         exit(0)
 
 else:
-    print("This program is not meant to be imported to other Python modules. Please run xborders as a standalone script!")
+    print("xborders: This program is not meant to be imported to other Python modules. Please run xborders as a standalone script!")


### PR DESCRIPTION
`-disable-version-warning` is now `--disable-version-warning` (`"disable-version-warning": true` in the config still works)

also, the error if the program is not called in __main__ now specifies that the error is coming from xborders