### PR TITLE
Take into account scale factor

### DIFF
--- a/xborders
+++ b/xborders
@@ -199,13 +199,19 @@ def get_args():
     return
 
 def get_screen_size(display): # TODO: Multiple monitor size support
-    mon_geoms = [{"r": display.get_monitor(i).get_geometry(), "s": display.get_monitor(i).get_scale_factor()} for i in range(display.get_n_monitors())]
-    print(mon_geoms[0])
-    x0 = min(w["r"].x for w in mon_geoms)
-    y0 = min(w["r"].y for w in mon_geoms)
-    x1 = max(w["r"].x + w["r"].width for w in mon_geoms)
-    y1 = max(w["r"].y + w["r"].height for w in mon_geoms)
-    s = max(w["s"] for w in mon_geoms)
+    mon_geoms = [
+        {
+            "rect": display.get_monitor(i).get_geometry(), 
+            "scale": display.get_monitor(i).get_scale_factor()
+        } 
+        for i in range(display.get_n_monitors())
+    ]
+
+    x0 = min(m["rect"].x for m in mon_geoms)
+    y0 = min(m["rect"].y for m in mon_geoms)
+    x1 = max(m["rect"].x + m["rect"].width for m in mon_geoms)
+    y1 = max(m["rect"].y + m["rect"].height for m in mon_geoms)
+    s = max(m["scale"] for m in mon_geoms)
 
     return (x1 - x0), (y1 - y0), s
 
@@ -387,10 +393,10 @@ class Highlight(Gtk.Window):
     def _calc_border_geometry(self, window):
         x, y, w, h = window.get_geometry()
         
-        w = w/self.scale
-        h = h/self.scale
-        x = x/self.scale
-        y = y/self.scale
+        w /= self.scale
+        h /= self.scale
+        x /= self.scale
+        y /= self.scale
 
         # Inside
         if BORDER_MODE == 0:

--- a/xborders
+++ b/xborders
@@ -199,14 +199,15 @@ def get_args():
     return
 
 def get_screen_size(display): # TODO: Multiple monitor size support
-    mon_geoms = [display.get_monitor(i).get_geometry() for i in range(display.get_n_monitors())]
+    mon_geoms = [{"r": display.get_monitor(i).get_geometry(), "s": display.get_monitor(i).get_scale_factor()} for i in range(display.get_n_monitors())]
+    print(mon_geoms[0])
+    x0 = min(w["r"].x for w in mon_geoms)
+    y0 = min(w["r"].y for w in mon_geoms)
+    x1 = max(w["r"].x + w["r"].width for w in mon_geoms)
+    y1 = max(w["r"].y + w["r"].height for w in mon_geoms)
+    s = max(w["s"] for w in mon_geoms)
 
-    x0 = min(r.x for r in mon_geoms)
-    y0 = min(r.y for r in mon_geoms)
-    x1 = max(r.x + r.width for r in mon_geoms)
-    y1 = max(r.y + r.height for r in mon_geoms)
-
-    return x1 - x0, y1 - y0
+    return (x1 - x0), (y1 - y0), s
 
 def notify_about_version(our_version: float, latest_version: float):
     notification_string = f"xborders has an update!  [{our_version} 🡢 {latest_version}]"
@@ -257,7 +258,7 @@ def notify_version():
 
 
 class Highlight(Gtk.Window):
-    def __init__(self, screen_width, screen_height):
+    def __init__(self, screen_width, screen_height, screen_scale):
         super().__init__(type=Gtk.WindowType.POPUP)
         notify_version()
 
@@ -279,6 +280,7 @@ class Highlight(Gtk.Window):
             pass
 
         self.resize(screen_width, screen_height)
+        self.scale = screen_scale
         self.move(0, 0)
 
         self.fullscreen()
@@ -384,6 +386,11 @@ class Highlight(Gtk.Window):
 
     def _calc_border_geometry(self, window):
         x, y, w, h = window.get_geometry()
+        
+        w = w/self.scale
+        h = h/self.scale
+        x = x/self.scale
+        y = y/self.scale
 
         # Inside
         if BORDER_MODE == 0:
@@ -438,9 +445,9 @@ def main():
     get_args()
     root = Gdk.get_default_root_window()
     screen = root.get_screen()
-    screen_width, screen_height = get_screen_size(Gdk.Display.get_default())
+    screen_width, screen_height, screen_scale = get_screen_size(Gdk.Display.get_default())
 
-    win = Highlight(screen_width, screen_height)
+    win = Highlight(screen_width, screen_height, screen_scale)
     Gtk.main()
 
 if __name__ == "__main__":


### PR DESCRIPTION
Scale the border position based on the scale factor.

For example with `GDK_SCALE=2`
Before:
![Screenshot from 2022-08-26 17-25-54](https://user-images.githubusercontent.com/3300824/187002493-29650d3f-2fa7-4050-a5b5-e75ea473c36d.png)

After:
![Screenshot from 2022-08-26 17-23-53](https://user-images.githubusercontent.com/3300824/187002402-9275905d-5b3e-4c48-98c3-1c8aa84616f7.png)

