### PR TITLE
Add an option to hide borders when only one window is visible

### DIFF
--- a/xborders
+++ b/xborders
@@ -115,7 +115,7 @@ def get_args():
     parser.add_argument(
         "--smart-hide-border",
         action='store_true',
-        help="Don't print a border if the window is alone in the workspace."
+        help="Don't display a border if the window is alone in the workspace."
     )
     parser.add_argument(
         "--disable-version-warning",

--- a/xborders
+++ b/xborders
@@ -28,6 +28,7 @@ BORDER_R = 123
 BORDER_G = 88
 BORDER_B = 220
 BORDER_A = 1
+SMART_HIDE_BORDER = False
 NO_VERSION_NOTIFY = False
 OFFSETS = [0, 0, 0, 0]
 
@@ -112,6 +113,11 @@ def get_args():
         help="Whether to place the border on the outside, inside or in the center of windows. Values are `outside`, `inside`, `center`"
     )
     parser.add_argument(
+        "--smart-hide-border",
+        action='store_true',
+        help="Don't print a border if the window is alone in the workspace."
+    )
+    parser.add_argument(
         "--disable-version-warning",
         action='store_true',
         help="Send a notification if xborders is out of date."
@@ -173,6 +179,7 @@ def get_args():
     global BORDER_G
     global BORDER_B
     global BORDER_A
+    global SMART_HIDE_BORDER
     global NO_VERSION_NOTIFY
     global OFFSETS
 
@@ -183,6 +190,7 @@ def get_args():
     BORDER_B = args.border_blue
     BORDER_A = args.border_alpha
     NO_VERSION_NOTIFY = args.disable_version_warning
+    SMART_HIDE_BORDER = args.smart_hide_border
     OFFSETS = [
         args.positive_x_offset or 0,
         args.positive_y_offset or 0,
@@ -327,6 +335,12 @@ class Highlight(Gtk.Window):
     old_window = None
     old_signals_to_disconnect = [None, None]
 
+    def is_alone_in_workspace(self):
+        workspace = Wnck.Screen.get_active_workspace(self.wnck_screen)
+        windows = Wnck.Screen.get_windows(self.wnck_screen)
+        windows_on_workspace = list(filter(lambda w: w.is_visible_on_workspace(workspace), windows))
+        return len(windows_on_workspace) == 1
+
     # This event will trigger every active window change, it will queue a border to be drawn and then do nothing.
     # See: Signals available for the Wnck.Screen class:
     # https://lazka.github.io/pgi-docs/Wnck-3.0/classes/Screen.html#signals Signals available for the Wnck.Window
@@ -342,7 +356,7 @@ class Highlight(Gtk.Window):
         active_window = self.wnck_screen.get_active_window()
 
         self.border_path = [0, 0, 0, 0]
-        if active_window is not None:
+        if active_window is not None and not (SMART_HIDE_BORDER and self.is_alone_in_workspace()):
             # Find if the window has a 'geometry-changed' event connected.
 
             geom_signal_id = GObject.signal_lookup('geometry-changed', active_window)


### PR DESCRIPTION
Hi,

This patch adds the `--smart-hide-border` option to xborders. It fixes rendering issues related to the `smart_gaps` i3 option.

Without `--smart-hide-border`:
![fullscreen_without](https://user-images.githubusercontent.com/20858392/212493843-4872831d-c6f6-48f0-925a-38af0fdbbc7f.png)

With `--smart-hide-border`:
![fullscreen_with](https://user-images.githubusercontent.com/20858392/212493862-f06f244a-901c-400d-93b7-69e01887e997.png)