### PR TITLE
Include version inside script

### DIFF
--- a/xborders
+++ b/xborders
@@ -17,6 +17,8 @@ gi.require_version("Wnck", "3.0")
 gi.require_version("GObject", "2.0")
 from gi.repository import Gtk, Gdk, Wnck, GObject
 
+VERSION = 3.4
+
 INSIDE = 'inside'
 OUTSIDE = 'outside'
 CENTER = 'center'
@@ -46,16 +48,6 @@ def set_border_rgba(args):
     args.border_green = literal_value >> (2 * 8) & 0xFF
     args.border_blue = literal_value >> (1 * 8) & 0xFF
     args.border_alpha = (literal_value >> (0 * 8) & 0xFF) / 255  # map from 0 to 1
-
-
-def get_version():
-    our_location = os.path.dirname(os.path.abspath(__file__))
-
-    version_file = open(our_location + "/version.txt", "r")
-    our_version_string = version_file.read()
-    version_file.close()
-
-    return float(our_version_string)
 
 
 def get_args():
@@ -153,7 +145,7 @@ def get_args():
     )
     args = parser.parse_args()
     if args.version is True:
-        print(f"xborders v{get_version()}")
+        print(f"xborders v{VERSION}")
         exit(0)
     if args.border_rgba is not None:
         set_border_rgba(args)
@@ -218,8 +210,8 @@ def get_screen_size(display):  # TODO: Multiple monitor size support
     return x1 - x0, y1 - y0
 
 
-def notify_about_version(our_version: float, latest_version: float):
-    notification_string = f"xborders has an update!  [{our_version} 🡢 {latest_version}]"
+def notify_about_version(latest_version: float):
+    notification_string = f"xborders has an update!  [{VERSION} 🡢 {latest_version}]"
     completed_process = subprocess.run(
         ["notify-send", "--app-name=xborder", "--expire-time=5000", notification_string, "--action=How to Update?",
          "--action=Ignore Update"],
@@ -252,7 +244,6 @@ def notify_version():
         latest_version_string = request.content.decode("utf-8")
 
         latest_version = float(latest_version_string)
-        our_version = get_version()
 
         if os.path.isfile(our_location + "/.update_ignore.txt"):
             ignore_version_file = open(our_location + "/.update_ignore.txt", "r")
@@ -261,8 +252,8 @@ def notify_version():
             if ignored_version == latest_version:
                 return
 
-        if our_version < latest_version:
-            threading._start_new_thread(notify_about_version, (our_version, latest_version))
+        if VERSION < latest_version:
+            threading._start_new_thread(notify_about_version, (latest_version))
     except:
         subprocess.Popen(["notify-send", "--app-name=xborders", "ERROR: xborders couldn't get latest version!"])
 


### PR DESCRIPTION
I currently have an open PR for packaging xborders for nixpkgs, the NixOS package registry, https://github.com/NixOS/nixpkgs/pull/217402. The fact that xborders stores its version number in version.txt makes packaging difficult, since it's quite rigid in requiring that version.txt is next to the xborders executable.

In my packaging, I'm currently just replacing the contents of `get_version` with returning the version number:

```PY
def get_version():
    return 3.4
```

However, it'd be more ideal to contribute this to upstream so xborders doesn't need to be modified during packaging.

I've replaced `get_version` with a constant `VERSION` and updated xborders to use this instead. However, version.txt is kept, since that's currently being used to fetch the version number from GitHub.

Have you considered using GitHub releases? It'd make keeping track of releases a lot easier, and there should be some sort of API available for fetching the latest version number.

Also I'd like to note that `if VERSION < latest_version` is not a good approach for checking if there's a newer version, as version numbers aren't decimal numbers (e.g. 3.11 is a later version than 3.4, but 3.11 < 3.4). You might want to take a look into the [semver](https://pypi.org/project/semver/) package so this doesn't cause bugs in the future. Is xborders handling update checking really necessary though? It seems like it adds a lot of unnecessary complications.

Thank you for the great work on xborders!