### PR TITLE
apply-only option implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,33 @@ blur-background-exclude = [
 ### Config
 Configuration options can be found by passing in the argument `--help` on the command line, or by specifying a config file with the argument `-c`. The config file is just a simple json file with the keys being the same as the command-line arguments (except without the "--" at the beginning).
 
+Now you can specify only the apps to which you want to add a border, instead of all apps:
+```json
+{
+    "border-rgba": "#FFFFFFFF",
+    "border-radius": 14,
+    "border-width": 4,
+    "border-mode": "outside",
+    "apply-only": false,
+    "apply-only-list": ["Xfce4-terminal", "Alacritty", "kitty", "URxvt", "XTerm"],
+    "disable-version-warning": false,
+
+    "positive-x-offset": 0,
+    "positive-y-offset": 0,
+    "negative-x-offset": 0,
+    "negative-y-offset": 0
+}
+```
+
+The option `apply-only` is a flag which you can enable (by default is disabled), and `apply-only-list` is the list of `CLASSNAME` of your X apps.
+
+How to discover my terminal `CLASSNAME`:
+
+```bash
+xdotool getwindowclassname $WINDOWID
+```
+
+To discover other `CLASSNAME` of your apps, just search for them on the internet.
+
 # Updating
 cd into the xborders directory and run `git pull origin main`

--- a/example_config.json
+++ b/example_config.json
@@ -1,8 +1,10 @@
 {
-    "border-rgba": "0xFFFFFFFF",
+    "border-rgba": "#FFFFFFFF",
     "border-radius": 14,
     "border-width": 4,
     "border-mode": "outside",
+    "apply-only": false,
+    "apply-only-list": ["Xfce4-terminal", "Alacritty", "kitty", "URxvt", "XTerm"],
     "disable-version-warning": false,
 
     "positive-x-offset": 0,

--- a/xborders
+++ b/xborders
@@ -32,6 +32,8 @@ BORDER_B = 220
 BORDER_A = 1
 SMART_HIDE_BORDER = False
 NO_VERSION_NOTIFY = False
+APPLY_ONLY_FLAG = False
+APPLY_ONLY_LIST = []
 OFFSETS = [0, 0, 0, 0]
 
 
@@ -148,6 +150,12 @@ def get_args():
         action="store_true",
         help="Print the version of xborders and exit."
     )
+    parser.add_argument(
+        "--apply-only",
+        action="store_true",
+        help="Activate the apply-only option."
+    )
+
     args = parser.parse_args()
     if args.version is True:
         print(f"xborders v{VERSION}")
@@ -178,6 +186,8 @@ def get_args():
     global BORDER_A
     global SMART_HIDE_BORDER
     global NO_VERSION_NOTIFY
+    global APPLY_ONLY_FLAG
+    global APPLY_ONLY_LIST
     global OFFSETS
 
     BORDER_RADIUS = args.border_radius
@@ -188,6 +198,8 @@ def get_args():
     BORDER_A = args.border_alpha
     NO_VERSION_NOTIFY = args.disable_version_warning
     SMART_HIDE_BORDER = args.smart_hide_border
+    APPLY_ONLY_FLAG = args.apply_only
+    APPLY_ONLY_LIST = [classname.replace("_", "-") for classname in args.apply_only_list]
     OFFSETS = [
         args.positive_x_offset or 0,
         args.positive_y_offset or 0,
@@ -429,6 +441,11 @@ class Highlight(Gtk.Window):
         self.border_path = [x, y, w, h]
 
     def _draw(self, _wid, ctx):
+        if APPLY_ONLY_FLAG and APPLY_ONLY_LIST:
+            window_classname = _wid.wnck_screen.get_active_window().get_class_group_name()
+            if window_classname not in APPLY_ONLY_LIST:
+                return
+
         ctx.save()
         if self.border_path != [0, 0, 0, 0]:
             x, y, w, h = self.border_path


### PR DESCRIPTION
`apply-only` is an option that allows the users to choose what apps they want to add borders to. You still can add borders to all apps, just mark the `apply-only` option in JSON as `false`.